### PR TITLE
Fix first delay vault test

### DIFF
--- a/tests/delay-vault.test.ts
+++ b/tests/delay-vault.test.ts
@@ -43,13 +43,13 @@ describe("Describe entity assertions", () => {
     // 0xa16081f360e3847006db660bae1c6d1b2e17ec2a is the default address used in newMockEvent() function
     assert.fieldEquals(
       "GovernorUpdated",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
+      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a00000001",
       "oldGovernor",
       "0x0000000000000000000000000000000000000001"
     )
     assert.fieldEquals(
       "GovernorUpdated",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1",
+      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a00000001",
       "newGovernor",
       "0x0000000000000000000000000000000000000001"
     )

--- a/tests/delay-vault.test.ts
+++ b/tests/delay-vault.test.ts
@@ -43,13 +43,13 @@ describe("Describe entity assertions", () => {
     // 0xa16081f360e3847006db660bae1c6d1b2e17ec2a is the default address used in newMockEvent() function
     assert.fieldEquals(
       "GovernorUpdated",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a00000001",
+      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a01000000",
       "oldGovernor",
       "0x0000000000000000000000000000000000000001"
     )
     assert.fieldEquals(
       "GovernorUpdated",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a00000001",
+      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a01000000",
       "newGovernor",
       "0x0000000000000000000000000000000000000001"
     )


### PR DESCRIPTION
## Summary
- fix the entity ID expectation in `delay-vault.test.ts`

## Testing
- `npx graph test --version 0.6.0` *(fails: Matchstick exited with an error)*

------
https://chatgpt.com/codex/tasks/task_e_68572f3ac17483308a8253c41bccab3f