### PR TITLE
Update timestamp on every invest

### DIFF
--- a/src/extendedEntities/investProvider.ts
+++ b/src/extendedEntities/investProvider.ts
@@ -30,10 +30,11 @@ export function updateTotalUserInvested(poolId: BigInt, user: Bytes, amount: Big
         totalUserInvested.poolId = poolId
         totalUserInvested.user = user // make sure `user` field is of type `Bytes`
         totalUserInvested.amount = amount
-        totalUserInvested.blockTimestamp = blockTimestamp
     } else {
         totalUserInvested.amount = totalUserInvested.amount.plus(amount)
     }
+    // Always update the timestamp with the latest invest block
+    totalUserInvested.blockTimestamp = blockTimestamp
 
     totalUserInvested.save()
 }

--- a/tests/invest-provider.test.ts
+++ b/tests/invest-provider.test.ts
@@ -8,9 +8,19 @@ import {
 } from "matchstick-as/assembly/index"
 import { Address, BigInt } from "@graphprotocol/graph-ts"
 import { EIP712DomainChanged } from "../generated/schema"
-import { EIP712DomainChanged as EIP712DomainChangedEvent } from "../generated/InvestProvider/InvestProvider"
-import { handleEIP712DomainChanged } from "../src/invest-provider"
-import { createEIP712DomainChangedEvent } from "./invest-provider-utils"
+import {
+  EIP712DomainChanged as EIP712DomainChangedEvent,
+} from "../generated/InvestProvider/InvestProvider"
+import {
+  handleEIP712DomainChanged,
+  handleInvested,
+  handleNewPoolCreated,
+} from "../src/invest-provider"
+import {
+  createEIP712DomainChangedEvent,
+  createInvestedEvent,
+  createNewPoolCreatedEvent,
+} from "./invest-provider-utils"
 
 // Tests structure (matchstick-as >=0.5.0)
 // https://thegraph.com/docs/en/developer/matchstick/#tests-structure-0-5-0
@@ -35,5 +45,50 @@ describe("Describe entity assertions", () => {
 
     // More assert options:
     // https://thegraph.com/docs/en/developer/matchstick/#asserts
+  })
+})
+
+describe("TotalUserInvested timestamp updates", () => {
+  beforeAll(() => {
+    // create pool first
+    let poolId = BigInt.fromI32(1)
+    let owner = Address.fromString("0x0000000000000000000000000000000000000001")
+    let poolAmount = BigInt.fromI32(1000)
+    let poolEvent = createNewPoolCreatedEvent(poolId, owner, poolAmount)
+    handleNewPoolCreated(poolEvent)
+
+    let user = Address.fromString("0x0000000000000000000000000000000000000002")
+
+    let invest1 = createInvestedEvent(
+      poolId,
+      user,
+      BigInt.fromI32(100),
+      BigInt.fromI32(1),
+    )
+    invest1.block.timestamp = BigInt.fromI32(1000)
+    handleInvested(invest1)
+
+    let invest2 = createInvestedEvent(
+      poolId,
+      user,
+      BigInt.fromI32(50),
+      BigInt.fromI32(2),
+    )
+    invest2.block.timestamp = BigInt.fromI32(2000)
+    handleInvested(invest2)
+  })
+
+  afterAll(() => {
+    clearStore()
+  })
+
+  test("Timestamp overwritten on each invest", () => {
+    let id =
+      "0x" +
+      "1".padStart(64, "0") +
+      "-0x0000000000000000000000000000000000000002"
+    assert.entityCount("TotalUserInvested", 1)
+    assert.fieldEquals("TotalUserInvested", id, "amount", "150")
+    assert.fieldEquals("TotalUserInvested", id, "blockTimestamp", "2000")
   })
 })


### PR DESCRIPTION
## Summary
- update `updateTotalUserInvested` so `blockTimestamp` always reflects the last invest
- add unit test covering timestamp updates when multiple invests occur

## Testing
- `yarn build`
- `yarn test` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685940da2a9483309604f5d38f11868d