### PR TITLE
Switch CI scripts to Yarn

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,15 +21,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 'latest'
-          cache: 'npm'
+          cache: 'yarn'
           
       # (4) 3) Install project dependencies
-      - name: Install NPM dependencies
-        run: npm install
+      - name: Install Yarn dependencies
+        run: yarn install
 
       # (5) 4) Install Graph CLI globally
       - name: Install Graph CLI
-        run: npm install -g @graphprotocol/graph-cli
+        run: yarn global add @graphprotocol/graph-cli
 
       # (6) 5) Authenticate to The Graph (Hosted Service)
       - name: Authenticate with The Graph
@@ -40,9 +40,7 @@ jobs:
 
       # (7) 6) Run codegen & build
       - name: Generate typings and build subgraph
-        run: |
-          graph codegen
-          graph build
+        run: yarn codegen && yarn build
 
       # (8) 7) Deploy to “poolzfinancebsc” with version = release tag
       - name: Deploy subgraph to Hosted Service

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,13 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install
-      run: npm install
+      run: yarn install
 
     - name: Install @graphprotocol/graph-cli
-      run: npm install -g @graphprotocol/graph-cli
+      run: yarn global add @graphprotocol/graph-cli
 
     - name: Generate typings and build subgraph
-      run: |
-        graph codegen
-        graph build
+      run: yarn codegen && yarn build
 
     - name: Test
-      run: npm run test
+      run: yarn test


### PR DESCRIPTION
## Summary
- use `yarn install`, `yarn codegen && yarn build`, and `yarn test` in CI
- use Yarn in publish workflow and cache using yarn

## Testing
- `npx graph test -d` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e6719f5ac8330b5a5fd4688c3ffa9