### PR TITLE
Fix quotes in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: “Release → Build & Deploy Subgraph”
+name: "Release → Build & Deploy Subgraph"
 
 # (1) Trigger this workflow when a new Release is published
 on:
@@ -8,45 +8,45 @@ on:
 
 jobs:
   build-and-deploy:
-    name: Build & Deploy Subgraph (Release ${{ github.event.release.tag_name }})
+    name: "Build & Deploy Subgraph (Release ${{ github.event.release.tag_name }})"
     runs-on: ubuntu-latest
 
     steps:
       # (2) 1) Checkout your repository
-      - name: Checkout code
+      - name: "Checkout code"
         uses: actions/checkout@v4
 
       # (3) 2) Set up Node.js (for Graph CLI)
-      - name: Setup Node.js
+      - name: "Setup Node.js"
         uses: actions/setup-node@v4
         with:
-          node-version: 'latest'
-          cache: 'npm'
-          
+          node-version: "latest"
+          cache: "npm"
+
       # (4) 3) Install project dependencies
-      - name: Install NPM dependencies
+      - name: "Install NPM dependencies"
         run: npm install
 
       # (5) 4) Install Graph CLI globally
-      - name: Install Graph CLI
+      - name: "Install Graph CLI"
         run: npm install -g @graphprotocol/graph-cli
 
       # (6) 5) Authenticate to The Graph (Hosted Service)
-      - name: Authenticate with The Graph
+      - name: "Authenticate with The Graph"
         env:
           GRAPH_AUTH_TOKEN: ${{ secrets.GRAPH_AUTH_TOKEN }}
         run: |
           graph auth "$GRAPH_AUTH_TOKEN"
 
       # (7) 6) Run codegen & build
-      - name: Generate typings and build subgraph
+      - name: "Generate typings and build subgraph"
         run: |
           graph codegen
           graph build
 
-      # (8) 7) Deploy to “poolzfinancebsc” with version = release tag
-      - name: Deploy subgraph to Hosted Service
-        # Pass the release’s tag_name as VERSION
+        # (8) 7) Deploy to "poolzfinancebsc" with version = release tag
+      - name: "Deploy subgraph to Hosted Service"
+        # Pass the release's tag_name as VERSION
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |


### PR DESCRIPTION
## Summary
- convert workflow strings to use standard double quotes
- remove stray spaces in `.github/workflows/publish.yml`
- validate workflow syntax using `yamllint`

## Testing
- `yamllint -d '{extends: relaxed, rules: {line-length: {max: 120}}}' .github/workflows/publish.yml`

------
https://chatgpt.com/codex/tasks/task_e_685e671b3f5883308a49768cce8b4f1d